### PR TITLE
Score by date

### DIFF
--- a/R/S3_workflow.R
+++ b/R/S3_workflow.R
@@ -20,18 +20,6 @@ score_schema <- arrow::schema(
 
 
 
-forecast_schema = 
-  arrow::schema(target_id = arrow::string(), 
-                datetime = arrow::timestamp("us"), 
-                parameter=arrow::string(),
-                variable = arrow::string(), 
-                prediction=arrow::float64(),
-                family=arrow::string(),
-                reference_datetime=arrow::string(),
-                site_id=arrow::string(),
-                model_id = arrow::string(),
-                date=arrow::string()
-  )
 
 #' score_theme
 #' 
@@ -72,6 +60,20 @@ score_theme <- function(theme,
     
     fc_path <- s3_forecasts$path(glue::glue("parquet/{theme}"))
     
+    
+    
+    forecast_schema <- 
+      arrow::schema(target_id = arrow::string(), 
+                    datetime = arrow::timestamp("us"), 
+                    parameter=arrow::string(),
+                    variable = arrow::string(), 
+                    prediction=arrow::float64(),
+                    family=arrow::string(),
+                    reference_datetime=arrow::string(),
+                    site_id=arrow::string(),
+                    model_id = arrow::string(),
+                    date=arrow::string()
+    )
     ## We could assemble this from s3_forecasts$ls() instead
     fc <- arrow::open_dataset(fc_path, schema=forecast_schema)
     

--- a/R/S3_workflow.R
+++ b/R/S3_workflow.R
@@ -48,9 +48,6 @@ forecast_schema =
 #' This connection requires write access, e.g. by specifying 
 #  AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY env vars.
 #' @param s3_prov a connection from [arrow::s3_bucket]
-#' @param max_horizon days after the reference_date that a given forecast should cover.
-#' Can exceed the actual max horizon. Allows us to avoid re-scoring old forecasts when
-#' targets are updated with future values but leave old values unchanged.
 #' @param local_prov path to local csv file which will be used to 
 #' store provenance until theme is finished scoring.
 #' @export
@@ -59,7 +56,6 @@ score_theme <- function(theme,
                         s3_targets, 
                         s3_scores, 
                         s3_prov,
-                        max_horizon = 365L,
                         local_prov =  paste0(theme, "-scoring-prov.csv")
 ){
   

--- a/man/score_theme.Rd
+++ b/man/score_theme.Rd
@@ -10,7 +10,6 @@ score_theme(
   s3_targets,
   s3_scores,
   s3_prov,
-  max_horizon = 365L,
   local_prov = paste0(theme, "-scoring-prov.csv")
 )
 }
@@ -25,10 +24,6 @@ score_theme(
 This connection requires write access, e.g. by specifying}
 
 \item{s3_prov}{a connection from \link[arrow:s3_bucket]{arrow::s3_bucket}}
-
-\item{max_horizon}{days after the reference_date that a given forecast should cover.
-Can exceed the actual max horizon. Allows us to avoid re-scoring old forecasts when
-targets are updated with future values but leave old values unchanged.}
 
 \item{local_prov}{path to local csv file which will be used to
 store provenance until theme is finished scoring.}


### PR DESCRIPTION
@rqthomas okay, I think this is good to go. 

 I've rebuilt ticks, beetles, aquatics scores from scratch, terrestrial_daily is nearly done.  phenology looks like it will need another hour.  the initial scoring of terrestrial_30min may be more epic, I will try and parallelize it a bit and see what happens, but once the old scores are done it should be pretty efficient.  
 
 With the larger number of partitions this creates, specifying schema when using `open_dataset()` will probably be pretty critical....
I have created the object `forecast_schema` here for internal, though it's not exported (yet). 