### PR TITLE
S3 inventory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,6 @@ Imports:
     dplyr,
     ISOweek,
     scoringRules,
-    stringr,
     tidyr,
     forcats,
     rlang,
@@ -32,7 +31,9 @@ Imports:
     cpp11,
     parallel,
     brio,
-    read4cast (>= 0.0.0.9000)
+    read4cast (>= 0.0.0.9000),
+    fs,
+    stringi
 Suggests:
     bench,
     glue,

--- a/R/S3_workflow.R
+++ b/R/S3_workflow.R
@@ -27,7 +27,7 @@ score_theme <- function(theme,
 ){
   
   prov_download(s3_prov, local_prov)
-  prov_df <- readr::read_csv(local_prov, show_col_types = FALSE)
+  prov_df <- readr::read_csv(local_prov, col_types = "cc")
   on.exit(prov_upload(s3_prov, local_prov))
   
   s3_scores_path <- s3_scores$path(glue::glue("parquet/{theme}", theme=theme))
@@ -172,7 +172,9 @@ prov_download <- function(s3_prov, local_prov = "scoring_provenance.csv") {
 }
 
 prov_upload <- function(s3_prov, local_prov = "scoring_provenance.csv") {
-  prov <- arrow::open_dataset(local_prov, format="csv")
+  prov <- arrow::open_dataset(local_prov, format="csv",
+                              schema = arrow::schema(prov = arrow::string(),
+                                            new_id = arrow::string()))
   path <- s3_prov$path(local_prov)
   prov <- arrow::write_csv_arrow(prov, path)
 }

--- a/R/S3_workflow.R
+++ b/R/S3_workflow.R
@@ -44,8 +44,10 @@ score_theme <- function(theme,
     pb <- progress::progress_bar$new(format=
       glue::glue("  scoring {theme} [:bar] :percent in :elapsed, eta: :eta"),
       total = nrow(grouping), clear = FALSE, width= 80)
-    parallel::mclapply(1:n, score_group, grouping, bucket, target, prov_df,
-                       local_prov, s3_scores_path, pb, endpoint)
+    parallel::mclapply(seq_along(grouping[[1]]), score_group,
+                       grouping, bucket, target, prov_df,
+                       local_prov, s3_scores_path, pb, theme,
+                       endpoint)
 
    })
   ## now sync prov back to S3 -- overwrites
@@ -58,7 +60,7 @@ score_theme <- function(theme,
 
 score_group <- function(i, grouping, 
                         bucket, target, prov_df, local_prov,
-                        s3_scores_path, pb, endpoint) { 
+                        s3_scores_path, pb, theme, endpoint) { 
   pb$tick()
   group <- grouping[i,]
   ref <- lubridate::as_datetime(group$date)
@@ -85,7 +87,8 @@ score_group <- function(i, grouping,
   }
 }
 
-get_grouping <- function(s3_inv, theme,
+get_grouping <- function(s3_inv, 
+                         theme,
                          collapse=TRUE, 
                          endpoint="data.ecoforecast.org") {
   

--- a/R/S3_workflow.R
+++ b/R/S3_workflow.R
@@ -36,6 +36,7 @@ score_theme <- function(theme,
   on.exit(prov_upload(s3_prov, local_prov))
   
   s3_scores_path <- s3_scores$path(glue::glue("parquet/{theme}", theme=theme))
+  bucket <- "neon4cast-forecasts/"
   
   timing <- bench::bench_time({
     target <- get_target(theme, s3_targets)
@@ -43,7 +44,7 @@ score_theme <- function(theme,
     pb <- progress::progress_bar$new(format=
       glue::glue("  scoring {theme} [:bar] :percent in :elapsed, eta: :eta"),
       total = nrow(grouping), clear = FALSE, width= 80)
-    parallel::mclapply(1:n, score_group, grouping, fc, target, prov_df,
+    parallel::mclapply(1:n, score_group, grouping, bucket, target, prov_df,
                        local_prov, s3_scores_path, pb, endpoint)
 
    })
@@ -56,7 +57,7 @@ score_theme <- function(theme,
 # ex <- score_group(1, grouping, fc, target, prov_df, local_prov, s3_scores_path, pb)
 
 score_group <- function(i, grouping, 
-                        fc, target, prov_df, local_prov,
+                        bucket, target, prov_df, local_prov,
                         s3_scores_path, pb, endpoint) { 
   pb$tick()
   group <- grouping[i,]
@@ -184,3 +185,7 @@ get_fcst_arrow <- function(endpoint, bucket, theme, group) {
     dplyr::collect()
 }
 
+
+globalVariables(c("...1", "...2", "...3", "...4", "...5", 
+                  "add_filename", "theme", "n"), 
+                package="score4cast")

--- a/R/update_s3_inventory.R
+++ b/R/update_s3_inventory.R
@@ -1,0 +1,25 @@
+update_s3_inventory <- function(bucket, inventory) {
+  paths <- bucket$ls(recursive = TRUE)
+  full_path <- stringi::stri_detect_fixed(paths, ".")
+  parts <- stringi::stri_split(paths[full_path], fixed="/", simplify=TRUE)
+  parts <- tibble::as_tibble(parts, .name_repair = "universal")
+  dest <- inventory$path(bucket$base_path)
+  arrow::write_dataset(parts, dest)
+  
+}
+
+
+efi_update_inventory <- function() {
+  bucket <- arrow::s3_bucket("neon4cast-forecasts",
+                             endpoint_override = "data.ecoforecast.org",
+                             anonymous = TRUE)
+  
+  
+  inventory <- arrow::s3_bucket("neon4cast-inventory",
+                                endpoint_override = "data.ecoforecast.org",
+                                access_key = Sys.getenv("AWS_ACCESS_KEY_ID"),
+                                secret_key = Sys.getenv("AWS_SECRET_ACCESS_KEY"))
+  
+  update_s3_inventory(bucket, inventory)
+}
+

--- a/inst/examples/s3_duckdb_benchmark.R
+++ b/inst/examples/s3_duckdb_benchmark.R
@@ -1,0 +1,56 @@
+library(duckdb)
+library(glue)
+
+conn <- DBI::dbConnect(duckdb(), ":memory:")
+DBI::dbExecute(conn, "INSTALL 'httpfs';")
+DBI::dbExecute(conn, "LOAD 'httpfs';")
+
+
+
+get_fcst <- function(conn, endpoint, bucket, theme, group) {
+  parquet <- 
+    paste0("[", paste0(paste0("'",
+           "https://", endpoint, "/", bucket, "parquet/", theme,
+           "/model_id=", group$model_id, "/reference_datetime=",
+           stringi::stri_split_fixed(group$reference_datetime, ", ")[[1]],
+           "/date=", group$date, "/part-0.parquet", "'"), collapse = ","),
+          "]")
+  
+  tblname <- "forecast_subset"
+  view_query <-glue::glue("CREATE VIEW '{tblname}' ", 
+                    "AS SELECT * FROM parquet_scan({parquet}, HIVE_PARTITIONING=true);")
+  DBI::dbSendQuery(conn, view_query)
+  fc_i <- tbl(conn, tblname) |> collect()
+  DBI::dbSendQuery(conn, glue::glue("DROP VIEW {tblname}"))
+  fc_i
+}
+
+bench::bench_time( # 5.46 sec
+  fc <- get_fcst(conn, endpoint, bucket, theme, group)
+)
+
+bench::bench_time({ # 14.6 seconds
+fc_i <- paste0("s3://", bucket, "parquet/", theme,
+               "/model_id=", group$model_id, "/reference_datetime=",
+               stringi::stri_split_fixed(group$reference_datetime, ", ")[[1]],
+               "/date=", group$date, "/part-0.parquet",
+               "?endpoint_override=", endpoint) |> 
+  arrow::open_dataset(schema=forecast_schema()) |> 
+  collect()
+})
+
+## S3 can use a wildcard but it is much slower!
+parquet_s3 <-  paste0("'", "s3://", bucket, "parquet/", theme,
+           "/model_id=", group$model_id, "/reference_datetime=",
+           "*",
+           "/date=", group$date, "/part-0.parquet", "'")
+endpoint <- "data.ecoforecast.org"
+DBI::dbExecute(conn, glue("SET s3_endpoint='{endpoint}';"))
+DBI::dbExecute(conn, glue("SET s3_url_style='path';"))
+tblname <- "forecast_subset"
+view_query <-glue::glue("CREATE VIEW '{tblname}' ", 
+                        "AS SELECT * FROM parquet_scan({parquet_s3});")
+DBI::dbSendQuery(conn, view_query)
+fc_i <- tbl(conn, tblname) |> collect()
+DBI::dbSendQuery(conn, glue::glue("DROP VIEW {tblname}"))
+

--- a/inst/examples/s3_duckdb_benchmark.R
+++ b/inst/examples/s3_duckdb_benchmark.R
@@ -25,6 +25,7 @@ get_fcst <- function(conn, endpoint, bucket, theme, group) {
   fc_i
 }
 
+
 bench::bench_time( # 5.46 sec
   fc <- get_fcst(conn, endpoint, bucket, theme, group)
 )
@@ -38,6 +39,9 @@ fc_i <- paste0("s3://", bucket, "parquet/", theme,
   arrow::open_dataset(schema=forecast_schema()) |> 
   collect()
 })
+
+
+
 
 ## S3 can use a wildcard but it is much slower!
 parquet_s3 <-  paste0("'", "s3://", bucket, "parquet/", theme,
@@ -53,4 +57,6 @@ view_query <-glue::glue("CREATE VIEW '{tblname}' ",
 DBI::dbSendQuery(conn, view_query)
 fc_i <- tbl(conn, tblname) |> collect()
 DBI::dbSendQuery(conn, glue::glue("DROP VIEW {tblname}"))
+
+
 

--- a/inst/examples/s3_workflow_benchmarks.R
+++ b/inst/examples/s3_workflow_benchmarks.R
@@ -1,0 +1,126 @@
+
+theme = "aquatics"
+local_prov =  paste0(theme, "-scoring-prov.csv")
+# remotes::install_deps()
+devtools::load_all()
+library(arrow)
+ignore_sigpipe()
+readRenviron(path.expand("~/.Renviron"))
+Sys.setenv("AWS_EC2_METADATA_DISABLED"="TRUE")
+Sys.unsetenv("AWS_DEFAULT_REGION")
+
+
+endpoint = "data.ecoforecast.org"
+s3_forecasts <- arrow::s3_bucket("neon4cast-forecasts", endpoint_override = endpoint)
+s3_targets <- arrow::s3_bucket("neon4cast-targets", endpoint_override = endpoint)
+## Publishing Requires AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY set
+s3_scores <- arrow::s3_bucket("neon4cast-scores", endpoint_override = endpoint)
+s3_prov <- arrow::s3_bucket("neon4cast-prov", endpoint_override = endpoint, anonymous=TRUE)
+s3_scores <- arrow::SubTreeFileSystem$create("~/test_scores", arrow::LocalFileSystem$create())
+options("mc.cores"=4L)
+
+
+
+prov_download(s3_prov, local_prov)
+prov_df <- readr::read_csv(local_prov, show_col_types = FALSE)
+s3_scores_path <- s3_scores$path(glue::glue("parquet/{theme}", theme=theme))
+target <- get_target(theme, s3_targets)
+
+
+
+## slow when lots of files, even with schema!  just listing files is really slow... parquet hates small partitions.... (benchmark csv????)
+#bench::bench_time({ # 32 minutes!
+#  fc <- arrow::open_dataset(fc_path, schema=forecast_schema())
+#})
+
+## use filepaths to determine groups of `model_id`, `date` , where date is from `datetime`
+#bench::bench_time({ # 32 minutes!
+#  grouping <- get_grouping(fc_path)
+#})
+
+s3_inv <- arrow::s3_bucket("neon4cast-inventory",  endpoint_override = "data.ecoforecast.org", anonymous=TRUE)
+grouping <- get_grouping(s3_inv, theme)
+
+n <- nrow(grouping)
+
+pb <- progress::progress_bar$new(
+  format = glue::glue("  scoring {theme} [:bar] :percent in :elapsed,",
+                      " eta: :eta"),
+  total = n, 
+  clear = FALSE, width= 80)  
+
+# this for loop is the same as:
+# parallel::mclapply(1:n, score_group, grouping, fc, target, prov_df, local_prov, s3_scores_path, pb)
+#for (i in 1:n) { 
+parallel::mclapply(1:n, function(i) {  
+  ## this is the score_group() function:
+  pb$tick()
+  group <- grouping[i,]
+  ref <- lubridate::as_datetime(group$date)
+  
+  # NOTE: we cannot 'prefilter' grouping by prov, since once we have tg
+  # we want to use it to score, not access it twice...
+  tg <- target |>
+    filter(datetime >= ref, datetime < ref+lubridate::days(1))
+  
+  ## ID changes only if target has changed between dates for this group
+  id <- rlang::hash(list(group,  tg))
+
+  if (!prov_has(id, prov_df)) {
+
+    bucket <- s3_forecasts$base_path
+    get_fcst_arrow(endpoint, bucket, theme, group) |> 
+      filter(!is.na(family)) |>
+      crps_logs_score(tg) |>
+      mutate(date = group$date) |>
+      arrow::write_dataset(s3_scores_path,
+                           partitioning = c("model_id",
+                                            "date"))
+    prov_add(id, local_prov)
+  }
+})
+
+
+
+## arrow method is a bit slower?
+get_fcst_arrow <- function(endpoint, bucket, theme, group) {
+  paste0("s3://", bucket, "parquet/", theme,
+         "/model_id=", group$model_id, "/reference_datetime=",
+         stringi::stri_split_fixed(group$reference_datetime, ", ")[[1]],
+         "/date=", group$date, "/part-0.parquet",
+         "?endpoint_override=", endpoint) |> 
+    arrow::open_dataset(schema=forecast_schema()) |> 
+    collect()
+}
+
+
+
+## Helper fuction to open a forecast subset with duckdb
+get_fcst_duckdb <- function(conn, endpoint, bucket, theme, group) {
+  
+  conn <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
+  DBI::dbExecute(conn, "INSTALL 'httpfs';")
+  DBI::dbExecute(conn, "LOAD 'httpfs';")
+  
+  
+  parquet <- 
+    paste0("[", paste0(paste0("'",
+                              "https://", endpoint, "/", bucket, "parquet/", theme,
+                              "/model_id=", group$model_id, "/reference_datetime=",
+                              stringi::stri_split_fixed(group$reference_datetime, ", ")[[1]],
+                              "/date=", group$date, "/part-0.parquet", "'"), collapse = ","),
+           "]")
+  
+  tblname <- "forecast_subset"
+  view_query <-
+    glue::glue("CREATE VIEW '{tblname}' ", 
+               "AS SELECT * FROM parquet_scan({parquet}, ",
+               "HIVE_PARTITIONING=true);")
+  DBI::dbSendQuery(conn, view_query)
+  fc_i <- dplyr::tbl(conn, tblname) |> dplyr::collect()
+  DBI::dbSendQuery(conn, glue::glue("DROP VIEW {tblname}"))
+  fc_i
+}
+
+
+

--- a/inst/examples/s3_workflow_benchmarks.R
+++ b/inst/examples/s3_workflow_benchmarks.R
@@ -1,4 +1,3 @@
-
 theme = "aquatics"
 local_prov =  paste0(theme, "-scoring-prov.csv")
 # remotes::install_deps()
@@ -9,37 +8,29 @@ readRenviron(path.expand("~/.Renviron"))
 Sys.setenv("AWS_EC2_METADATA_DISABLED"="TRUE")
 Sys.unsetenv("AWS_DEFAULT_REGION")
 
-
 endpoint = "data.ecoforecast.org"
 s3_forecasts <- arrow::s3_bucket("neon4cast-forecasts", endpoint_override = endpoint)
 s3_targets <- arrow::s3_bucket("neon4cast-targets", endpoint_override = endpoint)
 ## Publishing Requires AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY set
 s3_scores <- arrow::s3_bucket("neon4cast-scores", endpoint_override = endpoint)
-s3_prov <- arrow::s3_bucket("neon4cast-prov", endpoint_override = endpoint, anonymous=TRUE)
+s3_prov <- arrow::s3_bucket("neon4cast-prov", endpoint_override = endpoint)
 s3_scores <- arrow::SubTreeFileSystem$create("~/test_scores", arrow::LocalFileSystem$create())
 options("mc.cores"=4L)
-
-
 
 prov_download(s3_prov, local_prov)
 prov_df <- readr::read_csv(local_prov, show_col_types = FALSE)
 s3_scores_path <- s3_scores$path(glue::glue("parquet/{theme}", theme=theme))
 target <- get_target(theme, s3_targets)
 
-
-
-## slow when lots of files, even with schema!  just listing files is really slow... parquet hates small partitions.... (benchmark csv????)
-#bench::bench_time({ # 32 minutes!
-#  fc <- arrow::open_dataset(fc_path, schema=forecast_schema())
-#})
-
-## use filepaths to determine groups of `model_id`, `date` , where date is from `datetime`
-#bench::bench_time({ # 32 minutes!
-#  grouping <- get_grouping(fc_path)
-#})
-
 s3_inv <- arrow::s3_bucket("neon4cast-inventory",  endpoint_override = "data.ecoforecast.org", anonymous=TRUE)
-grouping <- get_grouping(s3_inv, theme)
+grouping <- get_grouping(s3_inv, theme, collapse = TRUE)
+
+
+## benchmark full
+grouping <- grouping
+
+## benchmark on a subset:
+##grouping <- grouping |> mutate(model_id == "cb_prophet")
 
 n <- nrow(grouping)
 
@@ -51,76 +42,39 @@ pb <- progress::progress_bar$new(
 
 # this for loop is the same as:
 # parallel::mclapply(1:n, score_group, grouping, fc, target, prov_df, local_prov, s3_scores_path, pb)
-#for (i in 1:n) { 
-parallel::mclapply(1:n, function(i) {  
-  ## this is the score_group() function:
-  pb$tick()
-  group <- grouping[i,]
-  ref <- lubridate::as_datetime(group$date)
-  
-  # NOTE: we cannot 'prefilter' grouping by prov, since once we have tg
-  # we want to use it to score, not access it twice...
-  tg <- target |>
-    filter(datetime >= ref, datetime < ref+lubridate::days(1))
-  
-  ## ID changes only if target has changed between dates for this group
-  id <- rlang::hash(list(group,  tg))
 
-  if (!prov_has(id, prov_df)) {
-
-    bucket <- s3_forecasts$base_path
-    get_fcst_arrow(endpoint, bucket, theme, group) |> 
-      filter(!is.na(family)) |>
-      crps_logs_score(tg) |>
-      mutate(date = group$date) |>
-      arrow::write_dataset(s3_scores_path,
-                           partitioning = c("model_id",
-                                            "date"))
-    prov_add(id, local_prov)
+bench::bench_time({
+  for (i in 1:n) { 
+  #furrr::future_map(1:n, function(i) {  
+    ## this is the score_group() function:
+    pb$tick()
+    group <- grouping[i,]
+    ref <- lubridate::as_datetime(group$date)
+    
+    # NOTE: we cannot 'prefilter' grouping by prov, since once we have tg
+    # we want to use it to score, not access it twice...
+    tg <- target |>
+      filter(datetime >= ref, datetime < ref+lubridate::days(1))
+    
+    ## ID changes only if target has changed between dates for this group
+    id <- rlang::hash(list(grouping[i, c("model_id", "date")],  tg))
+    new_id <- rlang::hash(list(group,  tg))
+    
+    if (!prov_has(id, prov_df, "prov") | !prov_has(new_id, prov_df, "new_id")) {
+        bucket <- 
+        fc <- get_fcst_arrow(endpoint, "neon4cast-forecasts", theme, group)
+        fc |> 
+        filter(!is.na(family)) |> #hhhmmmm? what should we be doing about these forecasts?
+        crps_logs_score(tg) |>
+        mutate(date = as.Date(datetime)) |>
+        arrow::write_dataset(s3_scores_path,
+                             partitioning = c("model_id",
+                                              "date"))
+      prov_add(new_id, local_prov)
+    }
   }
 })
 
 
-
-## arrow method is a bit slower?
-get_fcst_arrow <- function(endpoint, bucket, theme, group) {
-  paste0("s3://", bucket, "parquet/", theme,
-         "/model_id=", group$model_id, "/reference_datetime=",
-         stringi::stri_split_fixed(group$reference_datetime, ", ")[[1]],
-         "/date=", group$date, "/part-0.parquet",
-         "?endpoint_override=", endpoint) |> 
-    arrow::open_dataset(schema=forecast_schema()) |> 
-    collect()
-}
-
-
-
-## Helper fuction to open a forecast subset with duckdb
-get_fcst_duckdb <- function(conn, endpoint, bucket, theme, group) {
-  
-  conn <- DBI::dbConnect(duckdb::duckdb(), ":memory:")
-  DBI::dbExecute(conn, "INSTALL 'httpfs';")
-  DBI::dbExecute(conn, "LOAD 'httpfs';")
-  
-  
-  parquet <- 
-    paste0("[", paste0(paste0("'",
-                              "https://", endpoint, "/", bucket, "parquet/", theme,
-                              "/model_id=", group$model_id, "/reference_datetime=",
-                              stringi::stri_split_fixed(group$reference_datetime, ", ")[[1]],
-                              "/date=", group$date, "/part-0.parquet", "'"), collapse = ","),
-           "]")
-  
-  tblname <- "forecast_subset"
-  view_query <-
-    glue::glue("CREATE VIEW '{tblname}' ", 
-               "AS SELECT * FROM parquet_scan({parquet}, ",
-               "HIVE_PARTITIONING=true);")
-  DBI::dbSendQuery(conn, view_query)
-  fc_i <- dplyr::tbl(conn, tblname) |> dplyr::collect()
-  DBI::dbSendQuery(conn, glue::glue("DROP VIEW {tblname}"))
-  fc_i
-}
-
-
+## arrow method is a bit slow
 

--- a/man/score_theme.Rd
+++ b/man/score_theme.Rd
@@ -10,7 +10,9 @@ score_theme(
   s3_targets,
   s3_scores,
   s3_prov,
-  local_prov = paste0(theme, "-scoring-prov.csv")
+  local_prov = paste0(theme, "-scoring-prov.csv"),
+  endpoint = "data.ecoforecast.org",
+  s3_inv = arrow::s3_bucket("neon4cast-inventory", endpoint_override = endpoint)
 )
 }
 \arguments{
@@ -27,6 +29,10 @@ This connection requires write access, e.g. by specifying}
 
 \item{local_prov}{path to local csv file which will be used to
 store provenance until theme is finished scoring.}
+
+\item{endpoint}{endpoint must be passed explicitly for s3_forecast bucket}
+
+\item{s3_inv}{parquet-based  S3 inventory of forecast filepaths}
 }
 \description{
 A helper utility to score a collection of forecasts efficiently


### PR DESCRIPTION
- By using S3 inventory, scoring runs on fully-scored themes should now take seconds instead of over an hour.  
- New prov trace should trigger rescore of a date when it an existing model adds new reference-datetimes.  (Previously, if a given model already had some reference-datetimes predicting said date, new "hindcasts" of the same model predicting the same date but with a different reference-datetime (i.e. different horizon) would not be scored.  This caused 'backfilled' forecasts to be omitted.  (Thanks @OlssonF for catching this!)